### PR TITLE
Add SSL configuration based on database port in proxy setup

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,16 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Ensure cancel is called to release resources if main exits before signal
 
-	p := proxy.NewProxy(config.CFG.SourceDatabaseServer, config.CFG.SourceDatabasePort, ctx)
+	var useSSL bool
+	if config.CFG.SourceDatabasePort == 3306 {
+		logger.Println("SourceDatabasePort is 3306, disabling SSL")
+		useSSL = false
+	} else {
+		logger.Println("Enabling SSL for non-default port")
+		useSSL = true
+	}
+
+	p := proxy.NewProxy(config.CFG.SourceDatabaseServer, config.CFG.SourceDatabasePort, useSSL, ctx)
 	p.EnableDecoding = true
 
 	var wg sync.WaitGroup

--- a/pkg/models/Proxy.go
+++ b/pkg/models/Proxy.go
@@ -8,6 +8,7 @@ import (
 type Proxy struct {
 	Host           string
 	Port           int
+	UseSSL         bool
 	ConnectionID   uint64
 	EnableDecoding bool
 	Ctx            context.Context

--- a/pkg/proxy/NewProxy.go
+++ b/pkg/proxy/NewProxy.go
@@ -6,11 +6,12 @@ import (
 	"github.com/supporttools/go-sql-proxy/pkg/models"
 )
 
-// NewProxy creates a new instance of the Proxy server.
-func NewProxy(host string, port int, ctx context.Context) *models.Proxy {
+// NewProxy creates a new instance of the Proxy server with optional SSL configuration.
+func NewProxy(host string, port int, useSSL bool, ctx context.Context) *models.Proxy {
 	return &models.Proxy{
-		Host: host,
-		Port: port,
-		Ctx:  ctx,
+		Host:   host,
+		Port:   port,
+		UseSSL: useSSL,
+		Ctx:    ctx,
 	}
 }


### PR DESCRIPTION
- Introduced `UseSSL` boolean to the `Proxy` struct to manage SSL settings.
- Updated the `NewProxy` function to accept the `useSSL` parameter.
- Implemented logic in `main.go` to disable SSL for default MySQL port (3306) and enable for others.