### PR TITLE
Update Dockerfile to use newer Go version and improve build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# Use a full-featured base image for building
-FROM golang:1.21.6-alpine3.18 AS builder
+# Use golang alpine image as the builder stage
+FROM golang:1.22.4-alpine3.20 AS builder
 
-# Install git if your project requires
-RUN apk update && apk add --no-cache git
+# Install git and other necessary tools
+RUN apk update && apk add --no-cache git bash
 
 # Set the Current Working Directory inside the container
 WORKDIR /src
@@ -14,21 +14,26 @@ COPY . .
 RUN go mod download
 
 # Version and Git Commit build arguments
-ARG VERSION=
+ARG VERSION
 ARG GIT_COMMIT
 ARG BUILD_DATE
 
 # Build the Go app with versioning information
-RUN GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/supporttools/go-sql-proxy/pkg/health.version=$VERSION -X github.com/supporttools/go-sql-proxy/pkg/health.GitCommit=$GIT_COMMIT -X github.com/supporttools/go-sql-proxy/pkg/health.BuildTime=$BUILD_DATE" -o /bin/go-sql-proxy
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo \
+-ldflags "-X github.com/supporttools/go-sql-proxy/pkg/health.version=$VERSION -X github.com/supporttools/go-sql-proxy/pkg/health.GitCommit=$GIT_COMMIT -X github.com/supporttools/go-sql-proxy/pkg/health.BuildTime=$BUILD_DATE" \
+-o /bin/go-sql-proxy
 
 # Start from scratch for the runtime stage
 FROM scratch
 
-# Set the working directory to /app
-WORKDIR /app
+# Set the Current Working Directory inside the container
+WORKDIR /root/
+
+# Copy CA certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy the built binary and config file from the builder stage
-COPY --from=builder /bin/go-sql-proxy /app/
+COPY --from=builder /bin/go-sql-proxy /bin/
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/app/go-sql-proxy"]
+ENTRYPOINT ["/bin/go-sql-proxy"]


### PR DESCRIPTION
- Changed base image to golang:1.22.4-alpine3.20
- Added bash installation along with git
- Updated build command to use CGO_ENABLED=0 for better optimizations
- Streamlined working directory paths in the runtime stage
- Ensured CA certificates are copied from the builder stage